### PR TITLE
Update the delegate method that handles HTTPS auth challenges

### DIFF
--- a/src/ofxGenericHTTPRequest.cpp
+++ b/src/ofxGenericHTTPRequest.cpp
@@ -824,9 +824,9 @@ void ofxGenericHTTPRequest::setDumpBodyOnError( bool dump )
 - (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
-        [[challenge sender] performDefaultHandlingForAuthenticationChallenge:challenge];
+        [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
     } else {
-        [[challenge sender] cancelAuthenticationChallenge:challenge];
+        [challenge.sender cancelAuthenticationChallenge:challenge];
     }
 }
 

--- a/src/ofxGenericHTTPRequest.cpp
+++ b/src/ofxGenericHTTPRequest.cpp
@@ -821,14 +821,5 @@ void ofxGenericHTTPRequest::setDumpBodyOnError( bool dump )
     }
 }
 
-- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
-{
-    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
-        [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
-    } else {
-        [challenge.sender cancelAuthenticationChallenge:challenge];
-    }
-}
-
 @end
 #endif

--- a/src/ofxGenericHTTPRequest.cpp
+++ b/src/ofxGenericHTTPRequest.cpp
@@ -821,25 +821,14 @@ void ofxGenericHTTPRequest::setDumpBodyOnError( bool dump )
     }
 }
 
-// TODO: FIX PROPIGATING PREDEF VALUE
-//#ifdef SSL_PROTOCOL_VERIFICATION_OFF
--( BOOL )connection:( NSURLConnection* )connection canAuthenticateAgainstProtectionSpace:( NSURLProtectionSpace * )protectionSpace
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    return [ protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust ];
-}
-
--( void )connection:( NSURLConnection*)connection didReceiveAuthenticationChallenge:( NSURLAuthenticationChallenge* )challenge
-{
-    if ( [ challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust ] )
-    {
-//        if ( [ trustedHosts containsObject:challenge.protectionSpace.host])
-        {
-            [ challenge.sender useCredential:[ NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust ] forAuthenticationChallenge:challenge ];
-        }
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        [[challenge sender] performDefaultHandlingForAuthenticationChallenge:challenge];
+    } else {
+        [[challenge sender] cancelAuthenticationChallenge:challenge];
     }
-    [ challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge ];
 }
-//#endif
 
 @end
 #endif


### PR DESCRIPTION
We were silently allowing HTTPS connections with invalid certs. This is bad because it opens our app's communications to MITM attacks, so we fixed it.

See also: https://github.com/lumoslabs/LumosityMobile/pull/963