### PR TITLE
Added insert and writeToFront methods.

### DIFF
--- a/src/ofxGenericValueStore.cpp
+++ b/src/ofxGenericValueStore.cpp
@@ -1102,6 +1102,14 @@ void ofxGenericValueStore::write( unsigned int index, ofPtr< ofxGenericValueStor
     }
 }
 
+void ofxGenericValueStore::writeToFront( ofPtr< ofxGenericValueStore > value )
+{
+    if ( asArray() )
+    {
+        insert(arrayBegin(), value);
+    }
+}
+
 float ofxGenericValueStore::read( unsigned int index, float defaultValue ) const
 {
     ofPtr< ofxGenericValueStore > value = read( index );
@@ -1328,6 +1336,15 @@ void ofxGenericValueStore::remove( ofxGenericValueStoreArrayIterator location )
     if ( asArray() )
     {
         asArray()->erase( location );
+    }
+}
+
+
+void ofxGenericValueStore::insert( ofxGenericValueStoreArrayIterator location,  ofPtr< ofxGenericValueStore > value)
+{
+    if ( asArray() )
+    {
+        asArray()->insert(arrayBegin(), 1, value);
     }
 }
 

--- a/src/ofxGenericValueStore.cpp
+++ b/src/ofxGenericValueStore.cpp
@@ -1102,10 +1102,9 @@ void ofxGenericValueStore::write( unsigned int index, ofPtr< ofxGenericValueStor
     }
 }
 
-void ofxGenericValueStore::writeToFront( ofPtr< ofxGenericValueStore > value )
+void ofxGenericValueStore::writeToFront(ofPtr<ofxGenericValueStore> value)
 {
-    if ( asArray() )
-    {
+    if (asArray()) {
         insert(arrayBegin(), value);
     }
 }
@@ -1340,10 +1339,9 @@ void ofxGenericValueStore::remove( ofxGenericValueStoreArrayIterator location )
 }
 
 
-void ofxGenericValueStore::insert( ofxGenericValueStoreArrayIterator location,  ofPtr< ofxGenericValueStore > value)
+void ofxGenericValueStore::insert(ofxGenericValueStoreArrayIterator location, ofPtr<ofxGenericValueStore> value)
 {
-    if ( asArray() )
-    {
+    if (asArray()) {
         asArray()->insert(arrayBegin(), 1, value);
     }
 }

--- a/src/ofxGenericValueStore.h
+++ b/src/ofxGenericValueStore.h
@@ -146,7 +146,7 @@ public:
     virtual void write( unsigned int index, const char* value, bool onlyIfFilled = false );
     virtual void write( unsigned int index, ofPoint value );
     virtual void write( unsigned int index, ofPtr< ofxGenericValueStore > value );
-    virtual void writeToFront( ofPtr< ofxGenericValueStore > value );
+    virtual void writeToFront(ofPtr<ofxGenericValueStore> value);
     
     virtual float   read( unsigned int index, float defaultValue ) const;
     virtual int     read( unsigned int index, int defaultValue ) const;
@@ -191,7 +191,7 @@ public:
     void remove( ofxGenericValueStoreObjectIterator location );
     void remove( ofxGenericValueStoreArrayIterator location );
     
-    void insert( ofxGenericValueStoreArrayIterator location,  ofPtr< ofxGenericValueStore > value);
+    void insert(ofxGenericValueStoreArrayIterator location, ofPtr< ofxGenericValueStore > value);
 
     string toJSONString() const;
     virtual Json::Value* convertToJSON() const;

--- a/src/ofxGenericValueStore.h
+++ b/src/ofxGenericValueStore.h
@@ -146,6 +146,7 @@ public:
     virtual void write( unsigned int index, const char* value, bool onlyIfFilled = false );
     virtual void write( unsigned int index, ofPoint value );
     virtual void write( unsigned int index, ofPtr< ofxGenericValueStore > value );
+    virtual void writeToFront( ofPtr< ofxGenericValueStore > value );
     
     virtual float   read( unsigned int index, float defaultValue ) const;
     virtual int     read( unsigned int index, int defaultValue ) const;
@@ -189,6 +190,8 @@ public:
     
     void remove( ofxGenericValueStoreObjectIterator location );
     void remove( ofxGenericValueStoreArrayIterator location );
+    
+    void insert( ofxGenericValueStoreArrayIterator location,  ofPtr< ofxGenericValueStore > value);
 
     string toJSONString() const;
     virtual Json::Value* convertToJSON() const;


### PR DESCRIPTION
This PR adds 2 new methods to insert items at specific locations in an value store and to write to the front of the value store.

The insert method is expensive compared to append to the bottom. Maybe it's Ok until we switch to the new core data stuff and this un-synced game results should not be super long in a normal users case.