### PR TITLE
Platform check issue

### DIFF
--- a/src/ofxGenericPlatform.cpp
+++ b/src/ofxGenericPlatform.cpp
@@ -47,11 +47,7 @@ string ofxGenericPlatform::deviceModelVersion()
 bool ofxGenericPlatform::isTablet()
 {
 #if TARGET_OS_IPHONE
-#ifdef UI_USER_INTERFACE_IDIOM
-    return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
-#else
-    return false;
-#endif
+    return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
 #endif
 }
 


### PR DESCRIPTION
This PR just uses the userInterfaceIdiom method without checking for it. We are supporting iOs 7 and above so no need for checks. 

Jira: https://lumoslabs.atlassian.net/browse/IOS-1194